### PR TITLE
Add redux-axios-middleware to installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Normalize data using [redux-axios-middleware](https://github.com/svrcekmichal/redux-axios-middleware) and [normalizr](https://github.com/paularmstrong/normalizr) schema
 
 ## Installation
-`yarn add redux-normalize-axios-middleware normalizr`
+`yarn add redux-normalize-axios-middleware redux-axios-middleware normalizr`
 
 ## Usage
 Add normalizeAxiosMiddleware


### PR DESCRIPTION
redux-axios-middleware is a peer dependency like normalizr, so it probably should be installed alongside that